### PR TITLE
Correct the Flow vs TypeScript conclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,53 +5,53 @@
 ## Why?
 
 A couple of days ago, I read comments in a blog post <http://michalzalecki.com/typescript-vs-flow/>
-and decided to run tests to show the major differences between *FlowType* and *TypeScript*.
+and decided to run tests to show the major differences between _FlowType_ and _TypeScript_.
 
 ## Source
 
-1. *FlowType* source file.
+1. _FlowType_ source file.
 
-    ```javascript
-    /* @flow */
+   ```javascript
+   /* @flow */
 
-    'use strict';
+   "use strict";
 
-    function Person(name: string) {
-        this.name = name;
-    }
+   function Person(name: string) {
+     this.name = name;
+   }
 
-    module.exports = Person;
-    ```
+   module.exports = Person;
+   ```
 
-2. *TypeScript* source file
+2. _TypeScript_ source file
 
-    ```javascript
-    'use strict';
+   ```javascript
+   'use strict';
 
-    class Person {
-        private name: string;
+   class Person {
+       private name: string;
 
-        constructor(name: string) {
-            this.name = name;
-        }
-    }
+       constructor(name: string) {
+           this.name = name;
+       }
+   }
 
-    export default Person;
-    ```
+   export default Person;
+   ```
 
 3. After compilation when I run the line
 
-    ```javascript
-    new Person(123);
-    ```
+   ```javascript
+   new Person(123);
+   ```
 
-* in the **FlowType** strategy I **got an error** &#x26D4;
+- in the **FlowType** strategy I **got an error** &#x26D4;
 
-    Hello BDD! Runtime error occur! &#x1F60E;
+  Hello BDD! Runtime error occur! &#x1F60E;
 
-* following the **TypeScript** way **nothing happens** ...
+- following the **TypeScript** way **nothing happens** ...
 
-    Eh... no runtime errors? Why? &#x1F631;
+  Eh... no runtime errors? Why? &#x1F631;
 
 ## How to run?
 
@@ -60,12 +60,20 @@ npm run build   # build basic scaffold
 npm test        # trigger unit tests!
 ```
 
+> **Correction (see [#3](https://github.com/piecioshka/test-flowtype-vs-typescript/issues/3)):** the original conclusion below was wrong.
+> Flow does **not** perform any runtime type checking — it is a static analysis tool, exactly like TypeScript.
+> The runtime error in the "FlowType" example above does **not** come from Flow; it comes from
+> [`babel-plugin-tcomb`](https://github.com/gcanti/babel-plugin-tcomb), which is enabled in
+> [`source/flowtype/.babelrc`](source/flowtype/.babelrc) and injects `tcomb` runtime assertions.
+> Flow's role here is only stripping the type annotations (`transform-flow-strip-types`).
+
 ## Conclusions
 
-**FlowType** was created to keep proper type during **runtime** (life application)
+Both **Flow** and **TypeScript** are **static** type checkers: they verify types ahead of time and
+emit plain JavaScript with the annotations removed. Neither adds runtime type checks on its own.
 
-**TypeScript** was created to keep proper type during **translation process**.
+The runtime error in the **FlowType** example comes from `babel-plugin-tcomb`, not from Flow.
 
 ## License
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Fixes the incorrect claim reported in #3. Flow is a static analysis tool and does not do runtime type checking; the runtime error in the example came from `babel-plugin-tcomb` (enabled in `source/flowtype/.babelrc`), not from Flow. Also switches the license link to https.

Closes #3